### PR TITLE
Update periodic_interval timeout

### DIFF
--- a/source/ns_sal.c
+++ b/source/ns_sal.c
@@ -295,7 +295,7 @@ uint32_t ns_sal_socket_periodic_interval(const struct socket *socket)
 {
     FUNC_ENTRY_TRACE("ns_sal_socket_periodic_interval()");
     if (SOCKET_STREAM == socket->family) {
-        return 0xffffffff;
+        return 0xfffff; // call periodic _task after ~17min
     }
     return 0;
 }

--- a/test/nanostack_tcp/main.cpp
+++ b/test/nanostack_tcp/main.cpp
@@ -37,6 +37,7 @@
 static TCPExample *tcpExample = NULL;
 static uint8_t mesh_network_state = MESH_DISCONNECTED;
 static Mesh6LoWPAN_ND *mesh_api = NULL;
+static Serial &pc = get_stdio_serial();
 
 /*
  * Callback from TCPExample class, called when data is available
@@ -78,7 +79,6 @@ void app_start(int, char **)
 {
     mesh_error_t status;
     // set tracing baud rate
-    static Serial pc(USBTX, USBRX);
     pc.baud(115200);
 
     mesh_api = (Mesh6LoWPAN_ND *)MeshInterfaceFactory::createInterface(MESH_TYPE_6LOWPAN_ND);

--- a/test/nanostack_udp/main.cpp
+++ b/test/nanostack_udp/main.cpp
@@ -33,6 +33,7 @@
 static UDPTest *udpTest = NULL;
 static mesh_connection_status_t mesh_network_state = MESH_DISCONNECTED;
 static Mesh6LoWPAN_ND *mesh_api = NULL;
+static Serial &pc = get_stdio_serial();
 
 /*
  * Callback from a UDPExample appl indicating data is available.
@@ -79,7 +80,6 @@ void app_start(int, char **)
 {
     mesh_error_t status;
     // set tracing baud rate
-    static Serial pc(USBTX, USBRX);
     pc.baud(115200);
 
     // init mesh api

--- a/test/system_test/main.cpp
+++ b/test/system_test/main.cpp
@@ -54,6 +54,7 @@ using mbed::util::FunctionPointer0;
 static mesh_connection_status_t mesh_network_state = MESH_DISCONNECTED;
 static AbstractMesh *mesh_api = NULL;
 static int tests_pass = 1;
+static Serial &pc = get_stdio_serial();
 
 using namespace minar;
 
@@ -175,7 +176,6 @@ void app_start(int, char **)
     tests_pass = 1;
 
     // set tracing baud rate
-    static Serial pc(USBTX, USBRX);
     pc.baud(115200);
 
     testExecutor = new TestExecutor;


### PR DESCRIPTION
Update peridoc_interval timeout from 0xFFFFFFFF to 0xFFFFF (~17m) as
minar maximum timeout value for K64F is ~0x7CFFFFF (~36h).

Use get_stdio_serial() to initialize serial interface.
